### PR TITLE
Fix Go downloading issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(GO_DIR)/bin/go:
 	mkdir -p $(GO_DIR)
 	rm -f $@
 	@echo Downloading and unpacking Go $(GO_VERSION) to $(GO_DIR)
-	curl -s $(GO_DOWNLOAD_URL) | tar xf - --strip-components=1 -C $(GO_DIR)
+	curl -s $(GO_DOWNLOAD_URL) | tar xfz - --strip-components=1 -C $(GO_DIR)
 
 # Clean up binary
 clean:


### PR DESCRIPTION
**Issue:**
Unable to get Go within compilation:
```
$ make
mkdir -p go-1.11.5
rm -f go-1.11.5/bin/go
Downloading and unpacking Go 1.11.5.linux-amd64 to go-1.11.5
curl -s https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | tar xf - --strip-components=1 -C go-1.11.5
tar: Archive is compressed. Use -z option
tar: Error is not recoverable: exiting now
Makefile:29: recipe for target 'go-1.11.5/bin/go' failed
make: *** [go-1.11.5/bin/go] Error 2
```

**Solution:**
add `-z option` for `tar` command.